### PR TITLE
Fix the rest of the component urls

### DIFF
--- a/client/screens/IconScreen.js
+++ b/client/screens/IconScreen.js
@@ -50,7 +50,8 @@ class IconScreen extends Component {
           componentProps={iconProps}
           importStatement={{
             named: ["Icon"],
-            path: "core/ui/client/components"
+            path: "core/ui/client/components",
+            source: "/imports/plugins/core/ui/client/components/icon/icon.jsx"
           }}
         >
           <Icon icon="fa fa-star" />

--- a/client/screens/ListsScreen.js
+++ b/client/screens/ListsScreen.js
@@ -42,7 +42,8 @@ class ListsScreen extends Component {
           title="List with different action types"
           importStatement={{
             named: ["List, ListItem"],
-            path: "core/ui/client/components"
+            path: "core/ui/client/components",
+            source: "/imports/plugins/core/ui/client/components/list/list.js"
           }}
         >
           <List>
@@ -62,7 +63,8 @@ class ListsScreen extends Component {
           componentProps={listItemProps}
           importStatement={{
             named: ["List, ListItem"],
-            path: "core/ui/client/components"
+            path: "core/ui/client/components",
+            source: "/imports/plugins/core/ui/client/components/list/listItem.js"
           }}
           wrapperComponent={<List />}
         >

--- a/client/screens/MetadataScreen.js
+++ b/client/screens/MetadataScreen.js
@@ -89,7 +89,7 @@ class MetadataScreen extends Component {
           componentProps={metaDataProps}
           importStatement={{
             named: ["Metadata"],
-            soruce: "/imports/plugins/core/ui/client/components/metadata/metadata.js"
+            source: "/imports/plugins/core/ui/client/components/metadata/metadata.js"
           }}
           title="Metadata, key / value table"
         >
@@ -103,7 +103,7 @@ class MetadataScreen extends Component {
           componentProps={metaItemProps}
           importStatement={{
             named: ["Metafield"],
-            soruce: "/imports/plugins/core/ui/client/components/metadata/metafield.js"
+            source: "/imports/plugins/core/ui/client/components/metadata/metafield.js"
           }}
           title="Metafield"
         >

--- a/client/screens/MultiSelectScreen.js
+++ b/client/screens/MultiSelectScreen.js
@@ -54,7 +54,7 @@ class MultiSelectScreen extends Component {
           componentProps={multiSelectProps}
           importStatement={{
             named: ["MultiSelect"],
-            soruce: "/imports/plugins/core/ui/client/components/multiselect/multiselect.js"
+            source: "/imports/plugins/core/ui/client/components/multiselect/multiselect.js"
           }}
           title="MultiSelect"
         >


### PR DESCRIPTION
Working off of @mikemurray's URL fixes for `Cards`, fixes `View on Github` URL path for `IconScreen`, `ListsScreen`, `MetadataScreen`, `MultiSelectScreen`

