### PR TITLE
chore: deprecate styleguide plugin and link to component library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
----
- ** NOTICE:** ⚠ This repository is archived for read-only reference purposes. Check out the [Reaction Component Library](https://github.com/reactioncommerce/reaction-component-library) for the replacement.
----
+***
+
+:warning: **NOTICE:** This repository is archived for read-only reference purposes. Check out the [Reaction Component Library](https://github.com/reactioncommerce/reaction-component-library) for the replacement.
+ 
+***
 
 # reaction-styleguide
 A plugin for Reaction, transforming it into a style guide and UI component playground.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> Note: This repository is archived for read-only reference purposes. Check out the [Reaction Component Library](https://github.com/reactioncommerce/reaction-component-library) for the replacement.
+
 # reaction-styleguide
 A plugin for Reaction, transforming it into a style guide and UI component playground.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-> Note: This repository is archived for read-only reference purposes. Check out the [Reaction Component Library](https://github.com/reactioncommerce/reaction-component-library) for the replacement.
+---
+ ** NOTICE:** ⚠ This repository is archived for read-only reference purposes. Check out the [Reaction Component Library](https://github.com/reactioncommerce/reaction-component-library) for the replacement.
+---
 
 # reaction-styleguide
 A plugin for Reaction, transforming it into a style guide and UI component playground.


### PR DESCRIPTION
## what this PR does
1. Adds a Deprecation note
2. Links to https://github.com/reactioncommerce/reaction-component-library

## after this PR is merged
please click `Archive` 